### PR TITLE
Stop ignoring property tests on FreeBSD 15

### DIFF
--- a/tests/functional/mod.rs
+++ b/tests/functional/mod.rs
@@ -97,7 +97,6 @@ mod create {
     use super::*;
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn async_() {
         require_fbsd15!();
 
@@ -110,7 +109,6 @@ mod create {
     }
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn cache() {
         require_fbsd15!();
 
@@ -123,7 +121,6 @@ mod create {
     }
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn compress() {
         require_fbsd15!();
 
@@ -163,7 +160,6 @@ mod create {
     }
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn mustdealloc() {
         require_fbsd15!();
 
@@ -197,7 +193,6 @@ mod create {
     }
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn readonly() {
         require_fbsd15!();
 
@@ -210,7 +205,6 @@ mod create {
     }
 
     #[test]
-    #[ignore = "https://github.com/asomers/mdconfig/issues/1"]
     fn reserve() {
         require_fbsd15!();
 


### PR DESCRIPTION
The latest GCE image, freebsd-15-0-current-amd64-ufs-20240606, should include this functionality.

Fixes #1