### PR TITLE
ci: update FreeBSD workflow freebsd_version to 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Start VM
       uses: vmactions/freebsd-vm@v1
       with:
-        release: ${{ matrix.freebsd_version }}
+        release: 15.1
         usesh: true
     - name: Install dependencies
       shell: freebsd {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - freebsd_version: "15.0"
+        - freebsd_version: "15.1"
           rust_version: "nightly"
           target: x86_64-unknown-freebsd
           arch: x86_64
@@ -33,7 +33,7 @@ jobs:
     - name: Start VM
       uses: vmactions/freebsd-vm@v1
       with:
-        release: 15.1
+        release: ${{ matrix.freebsd_version }}
         usesh: true
     - name: Install dependencies
       shell: freebsd {0}


### PR DESCRIPTION
Updates `.github/workflows/ci.yml` to use FreeBSD 15.1 by updating the `freebsd_version` in the matrix from `15.0` to `15.1`. The `release` value is derived from `${{ matrix.freebsd_version }}` rather than being hardcoded.